### PR TITLE
ClojureScript 0.0-2173

### DIFF
--- a/src/leiningen/new/mies_om/project.clj
+++ b/src/leiningen/new/mies_om/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-2156"]
+                 [org.clojure/clojurescript "0.0-2173"]
                  [org.clojure/core.async "0.1.267.0-0d7780-alpha"]
                  [om "0.5.0"]]
 


### PR DESCRIPTION
Update version of ClojureScript. This version works correctly with Om. 
