### PR TITLE
satisfy IRender protocol in default root component

### DIFF
--- a/src/leiningen/new/mies_om/core.cljs
+++ b/src/leiningen/new/mies_om/core.cljs
@@ -8,6 +8,8 @@
 
 (om/root
   (fn [app owner]
-    (dom/h1 nil (:text app)))
+    (reify om/IRender
+      (render [_]
+        (dom/h1 nil (:text app)))))
   app-state
   {:target (. js/document (getElementById "app"))})


### PR DESCRIPTION
This seems to be required in newer versions of Om otherwise people will run into

```
Uncaught Error: Assert failed: Invalid Om component fn,  does not return valid instance
(or (satisfies? IRender x) (satisfies? IRenderState x))
```

I couldn't find the appropriate note in Om's `CHANGES.md` so I could be wrong. It seems that most examples are now using `reify` though.
